### PR TITLE
Sketch 85 Compatibility

### DIFF
--- a/UserFlows.sketchplugin/Contents/Sketch/manifest.json
+++ b/UserFlows.sketchplugin/Contents/Sketch/manifest.json
@@ -241,7 +241,7 @@
   "compatibleVersion" : "52" ,
   "disableCocoaScriptPreprocessor" : true,
   "identifier" : "com.abynim.sketchplugins.userflows",
-  "version" : "2.3",
+  "version" : "2.3.1",
   "description" : "Generate user-flow diagrams from artboards in Sketch.",
   "homepage" : "https:\/\/abynim.github.io\/UserFlows",
   "authorEmail" : "abynimbalkar@gmail.com",

--- a/UserFlows.sketchplugin/Contents/Sketch/script.js
+++ b/UserFlows.sketchplugin/Contents/Sketch/script.js
@@ -625,7 +625,7 @@ var editConditionsForArtboard = function(currentArtboard, context, forceNewCondi
 			conditionBorder.setThickness(2);
 
 			conditionBoard.addLayers([conditionBox, conditionLabel]);
-			layersArray = MSLayerArray.arrayWithLayers([conditionBox, conditionLabel]);
+			layersArray = [conditionBox, conditionLabel];
 			conditionGroup = sketchVersion < sketchVersion52 ? MSLayerGroup.groupFromLayers(layersArray) : MSLayerGroup.groupWithLayers(layersArray);
 			conditionGroup.setName(strings["addCondition-conditionGroupName"] + " " + count);
 
@@ -1151,7 +1151,7 @@ var generateFlowWithSettings = function(context, settings, initialArtboard, sour
 	}
 
 	var sharedLayerStyles = sharedLayerStylesForContext(context);
-	var connectionLayers = MSLayerArray.arrayWithLayers(drawConnections(connections, sourcePage, exportScale, flowBackgroundColor, sharedLayerStyles));
+	var connectionLayers = drawConnections(connections, sourcePage, exportScale, flowBackgroundColor, sharedLayerStyles);
 	var connectionsGroup = sketchVersion < sketchVersion52 ? MSLayerGroup.groupFromLayers(connectionLayers) : MSLayerGroup.groupWithLayers(connectionLayers);
 	connectionsGroup.setName(strings["generateFlow-connectionsGroupName"]);
 	artboardBitmapLayers.push(connectionsGroup);
@@ -1161,7 +1161,7 @@ var generateFlowWithSettings = function(context, settings, initialArtboard, sour
 	for (var i = 0; i < artboardBitmapLayers.length; i++) {
 		groupBounds = CGRectUnion(groupBounds, artboardBitmapLayers[i].absoluteRect().rect());
 	}
-	var layers = MSLayerArray.arrayWithLayers(artboardBitmapLayers);
+	var layers = artboardBitmapLayers;
 	var newGroup = sketchVersion < sketchVersion52 ? MSLayerGroup.groupFromLayers(layers) : MSLayerGroup.groupWithLayers(layers);
 	newGroup.setName(strings["generateFlow-flowGroupName"]);
 	newGroup.resizeToFitChildrenWithOption(1);
@@ -1450,7 +1450,7 @@ var sharedLayerStylesForContext = function(context) {
 
 var redrawConnections = function(context) {
 	var doc = context.document || context.actionContext.document;
-	var selectedLayers = doc.selectedLayers().layers();
+	var selectedLayers = doc.selectedLayers();
 
 	sketchVersion = getVersionNumberFromString(NSBundle.mainBundle().objectForInfoDictionaryKey("CFBundleShortVersionString"));
 
@@ -1504,12 +1504,11 @@ var redrawConnections = function(context) {
 	}
 
 	var sharedLayerStyles = sharedLayerStylesForContext(context);
-	var connectionLayers = MSLayerArray.arrayWithLayers(drawConnections(connections, doc.currentPage(), 1, nil, sharedLayerStyles));
+	var connectionLayers = drawConnections(connections, doc.currentPage(), 1, nil, sharedLayerStyles);
 	connectionsGroup = sketchVersion < sketchVersion52 ? MSLayerGroup.groupFromLayers(connectionLayers) : MSLayerGroup.groupWithLayers(connectionLayers);
 	connectionsGroup.setName("-Connections");
 	connectionsGroup.setIsLocked(1);
-	connectionsGroup.deselectLayerAndParent();
-	context.command.setValue_forKey_onLayer_forPluginIdentifier(true, "isConnectionsContainer", connectionsGroup, kPluginDomain);
+  context.command.setValue_forKey_onLayer(true,"isConnectionsContainer",connectionsGroup);
 
 	var loop = selectedLayers.objectEnumerator(), selectedLayer;
 	while (selectedLayer = loop.nextObject()) {

--- a/appcast.xml
+++ b/appcast.xml
@@ -6,6 +6,17 @@
     <description>Generate flow diagrams from Artboards in Sketch</description>
     <language>en</language>
     <item>
+      <title>UserFlows 2.3.1</title>
+      <description>
+        <![CDATA[
+          <ul>
+            <li>Sketch 85 Compatibility</li>
+          </ul>
+        ]]>
+      </description>
+      <enclosure url="https://github.com/abynim/UserFlows/archive/v2.zip" sparkle:version="2.3.1" />
+    </item>
+    <item>
       <title>UserFlows 2.3</title>
       <description>
         <![CDATA[


### PR DESCRIPTION
A few fixes to make the plugin work again, might not be everything but it's the core stuff...

- Fix for userInfo not being applied to connections group. Removing the pluginIdentifier solved the problem, and it's not necessary Sketch applies the plugin invoking the action as identifier by default.
- Fix for "doc.selectedLayers().layers is not a function". Dropping .layers() solved the problem.
- Fix for "Can't find variable: MSLayerArray". Removed MSLayerArray.arrayWithLayers and simply passing the layer objects seems to work fine.
- Fix for "connectionsGroup.deselectLayerAndParent is not a function". Simply removed this function, without it the user selections are retained despite the folder being added.